### PR TITLE
add utility functions for closing streams

### DIFF
--- a/stream_util.go
+++ b/stream_util.go
@@ -1,0 +1,54 @@
+package net
+
+import (
+	"errors"
+	"io"
+	"time"
+)
+
+// EOFTimeout is the maximum amount of time to wait to successfully observe an
+// EOF on the stream. Defaults to 60 seconds.
+var EOFTimeout = time.Second * 60
+
+// ErrExpectedEOF is returned when we read data while expecting an EOF.
+var ErrExpectedEOF = errors.New("read data when expecting EOF")
+
+// FullClose closes the stream and waits to read an EOF from the other side.
+//
+// * If it reads any data *before* the EOF, it resets the stream.
+// * If it doesn't read an EOF within EOFTimeout, it resets the stream.
+//
+// You'll likely want to invoke this as `go FullClose(stream)` to close the
+// stream in the background.
+func FullClose(s Stream) error {
+	if err := s.Close(); err != nil {
+		s.Reset()
+		return err
+	}
+	return AwaitEOF(s)
+}
+
+// AwaitEOF waits for an EOF on the given stream, returning an error if that
+// fails. It waits at most EOFTimeout (defaults to 1 minute) after which it
+// resets the stream.
+func AwaitEOF(s Stream) error {
+	// So we don't wait forever
+	s.SetDeadline(time.Now().Add(EOFTimeout))
+
+	// We *have* to observe the EOF. Otherwise, we leak the stream.
+	// Now, technically, we should do this *before*
+	// returning from SendMessage as the message
+	// hasn't really been sent yet until we see the
+	// EOF but we don't actually *know* what
+	// protocol the other side is speaking.
+	n, err := s.Read([]byte{0})
+	if n > 0 || err == nil {
+		s.Reset()
+		return ErrExpectedEOF
+	}
+	if err != io.EOF {
+		s.Reset()
+		return err
+	}
+	return nil
+}

--- a/stream_util_test.go
+++ b/stream_util_test.go
@@ -1,0 +1,150 @@
+package net_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	inet "github.com/libp2p/go-libp2p-net"
+)
+
+var errCloseFailed = errors.New("close failed")
+var errWriteFailed = errors.New("write failed")
+var errReadFailed = errors.New("read failed")
+
+type stream struct {
+	inet.Stream
+
+	data []byte
+
+	failRead, failWrite, failClose bool
+
+	reset bool
+}
+
+func (s *stream) Reset() error {
+	s.reset = true
+	return nil
+}
+
+func (s *stream) Close() error {
+	if s.failClose {
+		return errCloseFailed
+	}
+	return nil
+}
+
+func (s *stream) SetDeadline(t time.Time) error {
+	s.SetReadDeadline(t)
+	s.SetWriteDeadline(t)
+	return nil
+}
+
+func (s *stream) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (s *stream) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (s *stream) Write(b []byte) (int, error) {
+	if s.failWrite {
+		return 0, errWriteFailed
+	}
+	return len(b), nil
+}
+
+func (s *stream) Read(b []byte) (int, error) {
+	var err error
+	if s.failRead {
+		err = errReadFailed
+	}
+	if len(s.data) == 0 {
+		if err == nil {
+			err = io.EOF
+		}
+		return 0, err
+	}
+	n := copy(b, s.data)
+	s.data = s.data[n:]
+	return n, err
+}
+
+func TestNormal(t *testing.T) {
+	var s stream
+	if err := inet.FullClose(&s); err != nil {
+		t.Fatal(err)
+	}
+	if s.reset {
+		t.Fatal("stream should not have been reset")
+	}
+}
+
+func TestFailRead(t *testing.T) {
+	var s stream
+	s.failRead = true
+	if inet.FullClose(&s) != errReadFailed {
+		t.Fatal("expected read to fail with:", errReadFailed)
+	}
+	if !s.reset {
+		t.Fatal("expected stream to be reset")
+	}
+}
+
+func TestFailClose(t *testing.T) {
+	var s stream
+	s.failClose = true
+	if inet.FullClose(&s) != errCloseFailed {
+		t.Fatal("expected close to fail with:", errCloseFailed)
+	}
+	if !s.reset {
+		t.Fatal("expected stream to be reset")
+	}
+}
+
+func TestFailWrite(t *testing.T) {
+	var s stream
+	s.failWrite = true
+	if err := inet.FullClose(&s); err != nil {
+		t.Fatal(err)
+	}
+	if s.reset {
+		t.Fatal("stream should not have been reset")
+	}
+}
+
+func TestReadDataOne(t *testing.T) {
+	var s stream
+	s.data = []byte{0}
+	if err := inet.FullClose(&s); err != inet.ErrExpectedEOF {
+		t.Fatal("expected:", inet.ErrExpectedEOF)
+	}
+	if !s.reset {
+		t.Fatal("stream have been reset")
+	}
+}
+
+func TestReadDataMany(t *testing.T) {
+	var s stream
+	s.data = []byte{0, 1, 2, 3}
+	if err := inet.FullClose(&s); err != inet.ErrExpectedEOF {
+		t.Fatal("expected:", inet.ErrExpectedEOF)
+	}
+	if !s.reset {
+		t.Fatal("stream have been reset")
+	}
+}
+
+func TestReadDataError(t *testing.T) {
+	var s stream
+	s.data = []byte{0, 1, 2, 3}
+	s.failRead = true
+	if err := inet.FullClose(&s); err != inet.ErrExpectedEOF {
+		t.Fatal("expected:", inet.ErrExpectedEOF)
+	}
+	if !s.reset {
+		t.Fatal("stream have been reset")
+	}
+}


### PR DESCRIPTION
Now that we support half-closed streams, fully closing a stream involves reading an EOF from the other side. However, doing this manually can be a pain.

Currently, we work around this by:

1. Not waiting for the EOF.
2. "Forgetting" the stream in the swarm on `Close`. This is changing with the swarm/transport refactor.

However, this is:

1. Incorrect (the stream is still open and could be read from).
2. Could leak the stream if the other side never closes it.
3. Could block the stream if the other side tries to write to it.

So, enter these helper functions. Most of our calls to `Close` will likely be replaced with `go FullClose(stream)` (or just `FullClose(stream)` if we're already in a goroutine).