### PR TITLE
NoDial context option

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -149,6 +149,10 @@ type Network interface {
 // There are no addresses associated with a peer when they were needed.
 var ErrNoRemoteAddrs = errors.New("no remote addresses")
 
+// ErrNoConn is returned when attempting to open a stream to a peer with the NoDial
+// option and no usable connection is available.
+var ErrNoConn = errors.New("no usable connection to peer")
+
 // Dialer represents a service that can dial out to peers
 // (this is usually just a Network, but other services may not need the whole
 // stack, and thus it becomes easier to mock)

--- a/options.go
+++ b/options.go
@@ -6,11 +6,20 @@ import (
 
 type noDialCtxKey struct{}
 
-// NoDial is a context option that instructs the network to not attempt a new
-// dial when opening a stream. The value of the key should be a string indicating
-// the source of the option.
-var NoDial = noDialCtxKey{}
+var noDial = noDialCtxKey{}
 
-func WithNoDial(ctx context.Context, src string) {
-	context.WithValue(ctx, NoDial, src)
+// WithNoDial constructs a new context with an option that instructs the network
+// to not attempt a new dial when opening a stream.
+func WithNoDial(ctx context.Context, reason string) {
+	context.WithValue(ctx, noDial, reason)
+}
+
+// GetNoDial returns true if the no dial option is set in the context.
+func GetNoDial(ctx context.Context) (nodial bool, reason string) {
+	v := ctx.Value(noDial)
+	if v != nil {
+		return true, v.(string)
+	}
+
+	return false, ""
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,16 @@
+package net
+
+import (
+	"context"
+)
+
+type noDialCtxKey struct{}
+
+// NoDial is a context option that instructs the network to not attempt a new
+// dial when opening a stream. The value of the key should be a string indicating
+// the source of the option.
+var NoDial = noDialCtxKey{}
+
+func WithNoDial(ctx context.Context, src string) {
+	context.WithValue(ctx, NoDial, src)
+}


### PR DESCRIPTION
This is an option to instruct the swarm not to dial when opening a new stream.
Essential for (non-active) relays that should never attempt any dials in hop streams.